### PR TITLE
Update repository stanza to match upstream

### DIFF
--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -9,7 +9,7 @@
 
 - name: Install the repo (Debian-like)
   apt_repository: >
-    repo='deb http://pkg.duosecurity.com/{{ ansible_distribution }} {{ ansible_distribution_release }} main'
+    repo='deb [arch=amd64] https://pkg.duosecurity.com/{{ ansible_distribution }} {{ ansible_distribution_release }} main'
   when: ansible_os_family == 'Debian'
 
 


### PR DESCRIPTION
The current Duo documentation has been updated to make the apt entry
multiarch aware and to use https by default.
This commit brings those changes to the role.